### PR TITLE
numeric.mapreduce support for scalars

### DIFF
--- a/src/numeric.js
+++ b/src/numeric.js
@@ -334,6 +334,7 @@ numeric.dim = function dim(x) {
 numeric.mapreduce = function mapreduce(body,init) {
     return numeric.Function('x','accum','_s','_k',
             'if(typeof accum === "undefined") accum = '+init+';\n'+
+            'if(typeof x === "number") { var xi = x; '+body+' return accum; }\n'+
             'if(typeof _s === "undefined") _s = numeric.dim(x);\n'+
             'if(typeof _k === "undefined") _k = 0;\n'+
             'var _n = _s[_k];\n'+


### PR DESCRIPTION
None of the functions created by `mapreduce` return a meaningful value when a scalar is passed in. I have a one-line change in `mapreduce` that facilitates this.

I'm not sure if this is a feature you would want, but for me, this preserves some of the MATLAB semantics that I have gotten used to. 

Also, I was confused as to how to run the tests. It seems like all of the testing scripts point at your server.
