### PR TITLE
CommonJS/RequireJS/AMD support

### DIFF
--- a/src/intro.js
+++ b/src/intro.js
@@ -1,0 +1,15 @@
+(function (root, factory) {
+    if (typeof exports === 'object') {
+        // Node.
+        module.exports = factory();
+    } else if (typeof define === 'function' && define.amd) {
+        // AMD. Register as an anonymous module.
+        define(factory);
+    } else {
+        // Browser globals (root is window)
+        root.numeric = factory();
+    }
+}(this, function() {
+
+'use strict';
+var numeric = function numeric(){};

--- a/src/numeric.js
+++ b/src/numeric.js
@@ -1,6 +1,3 @@
-"use strict";
-
-var numeric = (typeof exports === "undefined")?(function numeric() {}):(exports);
 if(typeof global !== "undefined") { global.numeric = numeric; }
 
 numeric.version = "1.2.6";

--- a/src/outro.js
+++ b/src/outro.js
@@ -1,0 +1,3 @@
+
+return numeric;
+}));

--- a/tools/build.sh
+++ b/tools/build.sh
@@ -14,7 +14,7 @@ if [ -f nodepid.log ]; then
 fi
 ver=`grep 'numeric.version.*=.*"' ../src/numeric.js | sed 's/numeric.version[ =]*"\([0-9.]*\)".*/\1/'`
 echo "Version is $ver"
-cat ../src/numeric.js ../src/seedrandom.js ../src/quadprog.js ../src/svd.js > ../lib/numeric-$ver.js
+cat ../src/intro.js ../src/numeric.js ../src/seedrandom.js ../src/quadprog.js ../src/svd.js ../src/outro.js > ../lib/numeric-$ver.js
 uglifyjs ../lib/numeric-$ver.js > ../lib/numeric-$ver.min.js
 cat jquery-1.7.1.min.js jquery.flot.min.js 'Crypto-JS v2.4.0/crypto/crypto-min.js' 'Crypto-JS v2.4.0/crypto-sha256/crypto-sha256.js' json2.js > megalib.js
 echo "" | cat closurelib.js sylvester.js - ../lib/numeric-$ver.min.js jquery-1.7.1.min.js jquery.flot.min.js  > benchlib.js


### PR DESCRIPTION
Hi
I've patched the code so that it should work as an AMD Module (with requireJS), a node module (as per commonJS syntax), or a browser global.

The declaration style keeps everything defined in a local scope and then only exposes window.numeric as a last resort.

**I've done a build, and all unit tests pass**

In order to get around the difficulty of the functions defined with the `Function` constructor, I had to wrap all of these constructions with a small internal function `_fn()` which simply does the following:

```
function _fn( fn ){
    fn.numeric = numeric;
    return fn;
}
```

so that the body of a function created with the `Function` constructor (which doesn't have access to the scope that defines numeric), will have access to numeric via

```
var numeric = arguments.callee.numeric;
```

I think this was the best way of getting around the scoping issues. But if anyone has a better way, I'm all ears.

Cheers!
