### PR TITLE
Avoid reaching out to numeric in global namespace in compiled code.

### DIFF
--- a/src/numeric.js
+++ b/src/numeric.js
@@ -38,7 +38,7 @@ numeric.largeArray = 50;
 numeric.compile = function () {
   var args = Array.prototype.slice.call(arguments);
   var body = args.pop();
-  body = 'return function (' + args.join(',') + ') {' + body + ';}';
+  body = 'return function (' + args.join(',') + ') {' + body + '}';
   return (new Function(['numeric'], body))(numeric);
 }
 


### PR DESCRIPTION
This replaces calls to javascript's `Function()` with calls to the new `numeric.compile()`, which is a wrapper that closures in the numeric object so that methods on it can be used inside compiled code. The motivation here is to allow using numeric without globally exporting the `numeric` symbol.

Done in collaboration with @ehberger.
