### PR TITLE
Fixed 100 rendered as 1e2 by prettyPrint

### DIFF
--- a/src/numeric.js
+++ b/src/numeric.js
@@ -56,9 +56,9 @@ numeric.prettyPrint = function prettyPrint(x) {
         if(typeof x === "string") { ret.push('"'+x+'"'); return false; }
         if(typeof x === "boolean") { ret.push(x.toString()); return false; }
         if(typeof x === "number") {
-            var a = fmtnum(x);
+            var a = parseFloat(x.toString()).toString();
             var b = x.toPrecision(numeric.precision);
-            var c = parseFloat(x.toString()).toString();
+            var c = fmtnum(x);
             var d = [a,b,c,parseFloat(b).toString(),parseFloat(c).toString()];
             for(k=1;k<d.length;k++) { if(d[k].length < a.length) a = d[k]; }
             ret.push(Array(numeric.precision+8-a.length).join(' ')+a);


### PR DESCRIPTION
Due to how prettyPrint was implemented, 100 would always be rendered as 1e2. Fixed that particular error. Still leaves open the issue of rendering 10000 as 1e4, for example.
